### PR TITLE
Fix: Dynamic Auth0 Redirect URI Handling for Vercel Deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ To set up this project with a new or different Auth0 account, or for initial set
 
         -   **Allowed Callback URLs**: Add `http://localhost:3000/callback.html` (for local development) and your production callback URL (e.g., `https://your-app.com/callback.html`). This is where Auth0 will redirect after successful login.
 
-        -   **Allowed Logout URLs**: Add `http://localhost:3000/login.html` (for local development) and your production login page URL (e.g., `https://your-app.com/login.html`). This is where Auth0 will redirect after successful logout.
+        -   **Allowed Logout URLs**: Add `http://localhost:3000/index.html` (for local development) and your production login page URL (e.g., `https://your-app.com/index.html`). This is where Auth0 will redirect after successful logout.
 
         -   Allowed Web Origins: Add `http://localhost:3000` (for local development) and your production app's origin (e.g., `https://your-app.com`).
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -23,8 +23,18 @@ const AUTH0_CLIENT_ID = '3H2O07Y9h101Gpx2hINM0avLDO20fA77'; // Client ID of your
 const AUTH0_AUDIENCE = 'https://dev-ky8umfzopcrqoft1.us.auth0.com/api/v2/'; // Optional: If you have a custom API, use its identifier (e.g., https://your-api.com)
 // The redirect_uri must exactly match one configured in your Auth0 Application's "Allowed Callback URLs".
 // It points to the HTML page in your frontend that will handle the Auth0 redirect.
-// const AUTH0_REDIRECT_URI = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}/callback.html` : `http://localhost:3000/callback.html`; // Adjust port if different
-const AUTH0_REDIRECT_URI = window.location.origin + '/callback.html';
+// Determine the Auth0 Redirect URI dynamically based on the hostname.
+// This allows switching between localhost and your Vercel production URL.
+let AUTH0_REDIRECT_URI;
+if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
+    // For local development
+    AUTH0_REDIRECT_URI = 'http://localhost:3000/callback.html';
+} else {
+    // For Vercel production deployment. Replace 'application-demo-gamma.vercel.app'
+    // with your actual canonical production domain if it changes.
+    // This assumes your Vercel production URL is stable and registered in Auth0.
+    AUTH0_REDIRECT_URI = 'https://application-demo-gamma.vercel.app/callback.html';
+}
 
 
 /**


### PR DESCRIPTION
### Pull Request Description:

**Summary:**

This PR resolves Auth0 login failures on Vercel preview deployments caused by `redirect_uri` mismatches. It implements dynamic detection of the application's base URL (localhost vs. canonical production URL) in the frontend and ensures this is consistently used in the Auth0 authentication flow.

**Change**

1.  **Frontend (`frontend/app.js`):**

    -   The `AUTH0_REDIRECT_URI` is now dynamically determined based on `window.location.hostname`.
    -   If `localhost` or `127.0.0.1`, it uses `http://localhost:3000/callback.html`.
    -   Otherwise, it explicitly uses the canonical production URL `https://application-demo-gamma.vercel.app/callback.html`.
    -   This dynamically determined `AUTH0_REDIRECT_URI` is passed in the `POST` request to the backend `/api/auth` endpoint.


**Reasoning:**

Auth0 strictly enforces `redirect_uri` matching. Vercel's preview deployments generate unique URLs that often don't match the fixed production `redirect_uri` registered in Auth0. This change ensures that the correct, pre-registered `redirect_uri` is always sent to Auth0, regardless of whether the app is running locally or on a Vercel production/preview environment.